### PR TITLE
Renovate, use local git copy to build image, add sample scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:bullseye
 MAINTAINER Michael Neese <madic@geekbundle.org>
 
 ENV HOME /root
@@ -8,7 +8,7 @@ RUN \
   apt-get -y upgrade && \
   apt-get install -y build-essential git liblzma-dev mkisofs unzip wget coreutils isolinux
 
-ADD ./build.sh /bin/build.sh
+COPY ./build.sh /bin/build.sh
 
 RUN chmod +x /bin/build.sh
 

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ if [ ! -d "$DIR_WIMBOOT" ]; then mkdir -p "$DIR_WIMBOOT"; fi
 if [ ! -d "$DIR_LOGS" ]; then mkdir -p "$DIR_LOGS"; fi
 
 # Write log to file
-exec &>$DIR_LOGS/build.log
+exec &> >(tee "$DIR_LOGS/build.log")
 
 # Download and compile ipxe
 if [ -d $DIR_IPXE/.git ]; then
@@ -38,7 +38,7 @@ if [ -d $DIR_IPXE/.git ]; then
 	echo
 else
 	echo "Cloning ipxe repository..."
-	git clone git://git.ipxe.org/ipxe.git $DIR_IPXE
+	git clone git://github.com/ipxe/ipxe.git $DIR_IPXE
 	echo
 fi
 if [ -n "$(ls -A /opt/ipxe.local)" ]; then echo "Copying custom configuration..."; echo; cp /opt/ipxe.local/* $DIR_IPXE/src/config/local/; fi

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This command allows you to run docker
+docker compose run --rm --build ipxe
+
+# The next line is an example of how to copy the .. file
+# to your server.  The name is changed on the server
+# so that you can configure your image according to the client.
+# (Here the DHCP server would need to set ha_undionly.kpxe as
+#  the image)
+# scp compile/ipxe/src/bin-x86_64-pcbios/undionly.kpxe root@arg1:/usr/local/tftp/ha_undionly.kpxe


### PR DESCRIPTION
Renovations
- The repository for ipxe changed - ipxe was complaining with an error that no longer exists;
- Using debian:bullseye

"Features"
- Show output from build script
  - Helps to know that the container is working, especially when using this for the first time.
  - Helps to know when it finished.
- add 'runDocker.sh'
  - Makes it easier to run and rerun - also uses modern docker compose.
  - Added comment to show how to scp the result to a target server
    - Helps to understand where one of the output files is located exactly.
- Use local git copy as the context (docker-compose.yml).
  - I made several updates to the build script/Dockerfile without any effect until I saw that the context was the remote git repository.